### PR TITLE
Update k8s.gcr.io to registry.k8s.io

### DIFF
--- a/best_practices/resources/pod-empty-dir.yaml
+++ b/best_practices/resources/pod-empty-dir.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-pd
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /cache

--- a/best_practices/resources/pod-hostpath.yaml
+++ b/best_practices/resources/pod-hostpath.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-hp
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-pd


### PR DESCRIPTION
This PR updates `k8s.gcr.io` to `registry.k8s.io`

Part of https://github.com/kubernetes/k8s.io/issues/4780