### PR TITLE
Add a demo for CEL support in kyverno policies

### DIFF
--- a/cel/check_deployment_replicas/bad_deployment.yaml
+++ b/cel/check_deployment_replicas/bad_deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-fail
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container2
+        image: nginx

--- a/cel/check_deployment_replicas/check_deployment_replicas.yaml
+++ b/cel/check_deployment_replicas/check_deployment_replicas.yaml
@@ -1,0 +1,24 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-deployment-replicas
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: deployment-replicas
+      match:
+        any:
+        - resources:
+            kinds:
+              - Deployment
+      validate:
+        cel:
+          paramKind: 
+            apiVersion: rules.example.com/v1
+            kind: ReplicaLimit
+            name: "replica-limit-test.example.com"
+            namespace: "test-params"
+          expressions:
+            - expression: "object.spec.replicas <= params.maxReplicas"
+              messageExpression:  "'Deployment spec.replicas must be less than ' + string(params.maxReplicas)"

--- a/cel/check_deployment_replicas/crd.yaml
+++ b/cel/check_deployment_replicas/crd.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: replicalimits.rules.example.com
+spec:
+  group: rules.example.com
+  names:
+    kind: ReplicaLimit
+    plural: replicalimits
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            maxReplicas:
+              type: integer

--- a/cel/check_deployment_replicas/good_deployment.yaml
+++ b/cel/check_deployment_replicas/good_deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-pass
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container2
+        image: nginx

--- a/cel/check_deployment_replicas/replicaLimit.yaml
+++ b/cel/check_deployment_replicas/replicaLimit.yaml
@@ -1,0 +1,6 @@
+apiVersion: rules.example.com/v1
+kind: ReplicaLimit
+metadata:
+  name: "replica-limit-test.example.com"
+  namespace: test-params
+maxReplicas: 3

--- a/cel/disallow_host_path/bad_deployment.yaml
+++ b/cel/disallow_host_path/bad_deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: nginx-container
+        image: nginx
+        volumeMounts:
+          - name: udev
+            mountPath: /data
+      volumes:
+      - name: udev
+        hostPath:
+          path: /etc/udev

--- a/cel/disallow_host_path/disallow_host_path.yaml
+++ b/cel/disallow_host_path/disallow_host_path.yaml
@@ -1,0 +1,19 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-host-path
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: host-path
+      match:
+        any:
+        - resources:
+            kinds:
+              - Deployment
+      validate:
+        cel:
+          expressions:
+            - expression: "!has(object.spec.template.spec.volumes) || object.spec.template.spec.volumes.all(volume, !has(volume.hostPath))"
+              message: "HostPath volumes are forbidden. The field spec.template.spec.volumes[*].hostPath must be unset."

--- a/cel/disallow_host_path/good_deployment.yaml
+++ b/cel/disallow_host_path/good_deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: good-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: nginx-container
+        image: nginx
+        volumeMounts:
+          - name: udev
+            mountPath: /data
+      volumes:
+      - name: udev
+        emptyDir: {}

--- a/cel/disallow_host_port_range/bad_pod.yaml
+++ b/cel/disallow_host_port_range/bad_pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+spec:
+  containers:
+  - name: webserver
+    image: nginx:latest
+    ports:
+    - containerPort: 8080
+      hostPort: 80

--- a/cel/disallow_host_port_range/disallow_host_port_range.yaml
+++ b/cel/disallow_host_port_range/disallow_host_port_range.yaml
@@ -1,0 +1,22 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-host-port-range
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: host-port-range
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      celPreconditions:
+          - name: "first match condition in CEL"
+            expression: "object.metadata.name.matches('nginx-pod')"
+      validate:
+        cel:
+          expressions:
+          - expression: "object.spec.containers.all(container, !has(container.ports) || container.ports.all(port, !has(port.hostPort) || (port.hostPort >= 5000 && port.hostPort <= 6000)))"
+            message: "The only permitted hostPorts are in the range 5000-6000."

--- a/cel/disallow_host_port_range/good_pod.yaml
+++ b/cel/disallow_host_port_range/good_pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  containers:
+  - name: webserver
+    image: nginx:latest
+    ports:
+    - containerPort: 8080
+      hostPort: 80


### PR DESCRIPTION
Adding a demo for CEL support in kyverno policies. There are 3 policies:

1. disallow_host_path: It mainly illustrates the use of CEL expressions for validations aganist resources.
2. disallow_host_port_range: It mainly illustrates the use of CEL Preconditions.
3. check_deployment_replicas: It mainly illustrates the use of parameter resources in the policy.