### PR TITLE
Modify CEL policy as well as kyverno test file in VAP

### DIFF
--- a/cel/check_deployment_replicas/check_deployment_replicas.yaml
+++ b/cel/check_deployment_replicas/check_deployment_replicas.yaml
@@ -17,6 +17,7 @@ spec:
           paramKind: 
             apiVersion: rules.example.com/v1
             kind: ReplicaLimit
+          paramRef:
             name: "replica-limit-test.example.com"
             namespace: "test-params"
           expressions:

--- a/validating_admission_policies/cli_test/kyverno-test.yaml
+++ b/validating_admission_policies/cli_test/kyverno-test.yaml
@@ -5,12 +5,12 @@ resources:
   - deployment.yaml
 results:
   - policy: check-deployment-replicas
-    rule: object.spec.replicas <= 5
+    isVap: true
     resource: nginx-deployment-1
     kind: Deployment
     result: pass
   - policy: check-deployment-replicas
-    rule: object.spec.replicas <= 5
+    isVap: true
     resource: nginx-deployment-2
     kind: Deployment
     result: fail


### PR DESCRIPTION
1. Using `ParamRef` in Kyverno CEL policy.
2. Using `isVap` in kyverno-test.yaml to test the deployment aganist the K8s validating admission policy.